### PR TITLE
forkしたリポジトリからのPRではlint結果をコメントしないようにする

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -198,7 +198,7 @@ jobs:
         continue-on-error: true
       # lint結果をコメントに残す
       - name: Lint Comment
-        if: steps.lint.outputs.result != ''
+        if: github.event.pull_request.head.repo.full_name == github.repository && steps.lint.outputs.result != ''
         uses: actions/github-script@0.9.0
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
forkしたリポジトリからPRを投げた場合、CIに書き込み権限が与えられないため、lint結果を書き込む部分で失敗します。
したがって、forkしたリポジトリからPRを投げた場合はコメントしないようにします。